### PR TITLE
Update template files to support secrets in Prometheus configuration

### DIFF
--- a/recipes-tools/prometheus/files/prometheus.yml.input_example
+++ b/recipes-tools/prometheus/files/prometheus.yml.input_example
@@ -1,5 +1,6 @@
 {
   "prometheus": {
+    "instance_name": "tdx-builder-xx-yocto",
     "scrape_interval": "10s",
     "static_configs_default_labels": [
       {
@@ -32,7 +33,12 @@
     "remote_write": [
       {
         "name": "tdx-rbuilder-collector",
-        "url": "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-xxx/api/v1/remote_write"
+        "url": "https://aps-workspaces.us-east-2.amazonaws.com/workspaces/ws-xxx/api/v1/remote_write",
+        "sigv4": {
+          "access_key": "xxx",
+          "secret_key": "xxx",
+          "region": "us-east-2"
+        }
       }
     ]
   }

--- a/recipes-tools/prometheus/files/prometheus.yml.mustache
+++ b/recipes-tools/prometheus/files/prometheus.yml.mustache
@@ -15,6 +15,10 @@ scrape_configs:
       {{#prometheus.static_configs_default_labels}}
         {{label_key}}: {{label_value}}
       {{/prometheus.static_configs_default_labels}}
+    relabel_configs:
+    - source_labels: [__address__]
+      target_label: instance_name
+      replacement: {{prometheus.instance_name}}
 
   - job_name: "node-exporter"
     metrics_path: "/metrics"
@@ -24,6 +28,10 @@ scrape_configs:
       {{#prometheus.static_configs_default_labels}}
         {{label_key}}: {{label_value}}
       {{/prometheus.static_configs_default_labels}}
+    relabel_configs:
+    - source_labels: [__address__]
+      target_label: instance_name
+      replacement: {{prometheus.instance_name}}
 
   - job_name: "process-exporter"
     metrics_path: "/metrics"
@@ -33,6 +41,10 @@ scrape_configs:
       {{#prometheus.static_configs_default_labels}}
         {{label_key}}: {{label_value}}
       {{/prometheus.static_configs_default_labels}}
+    relabel_configs:
+    - source_labels: [__address__]
+      target_label: instance_name
+      replacement: {{prometheus.instance_name}}
 
   {{#prometheus.lighthouse_metrics.enabled}}
   - job_name: "lighthouse"
@@ -43,7 +55,12 @@ scrape_configs:
       {{#prometheus.static_configs_default_labels}}
         {{label_key}}: {{label_value}}
       {{/prometheus.static_configs_default_labels}}
+    relabel_configs:
+    - source_labels: [__address__]
+      target_label: instance_name
+      replacement: {{prometheus.instance_name}}
   {{/prometheus.lighthouse_metrics.enabled}}
+
 
   {{#prometheus.reth_metrics.enabled}}
   - job_name: "reth"
@@ -54,6 +71,10 @@ scrape_configs:
       {{#prometheus.static_configs_default_labels}}
         {{label_key}}: {{label_value}}
       {{/prometheus.static_configs_default_labels}}
+    relabel_configs:
+    - source_labels: [__address__]
+      target_label: instance_name
+      replacement: {{prometheus.instance_name}}
   {{/prometheus.reth_metrics.enabled}}
 
   {{#prometheus.rbuilder_metrics.enabled}}
@@ -65,6 +86,10 @@ scrape_configs:
       {{#prometheus.static_configs_default_labels}}
         {{label_key}}: {{label_value}}
       {{/prometheus.static_configs_default_labels}}
+    relabel_configs:
+    - source_labels: [__address__]
+      target_label: instance_name
+      replacement: {{prometheus.instance_name}}
   {{/prometheus.rbuilder_metrics.enabled}}
 
 remote_write:
@@ -73,7 +98,8 @@ remote_write:
     url: {{url}}
     {{#sigv4}}
     sigv4:
-      profile: {{profile}}
+      access_key: {{access_key}}
+      secret_key: {{secret_key}}
       region: {{region}}
     {{/sigv4}}
 


### PR DESCRIPTION
- Update template files to support secrets in Prometheus configuration
- Add support for relabel configs to remap the scrape endpoint address to the `instance_name`