### PR TITLE
Various fixes to obserability tools recipes

### DIFF
--- a/recipes-tools/fluent-bit/files/fluent-bit.init
+++ b/recipes-tools/fluent-bit/files/fluent-bit.init
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          fluent-bit
-# Required-Start:    $local_fs $network $named $time $syslog
+# Required-Start:    $local_fs $network $named $time $syslog fetch-config
 # Required-Stop:     $local_fs $network $named $time $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6

--- a/recipes-tools/node-exporter/files/node_exporter.init
+++ b/recipes-tools/node-exporter/files/node_exporter.init
@@ -15,7 +15,7 @@ USER="node_exporter"
 GROUP="node_exporter"
 PIDFILE="/var/run/node_exporter.pid"
 LOGFILE="/var/log/node_exporter.log"
-DAEMON_ARGS=""
+DAEMON_ARGS="--web.listen-address=127.0.0.1:9100"
 
 # Read configuration variable file if it is present
 [ -r /etc/default/node_exporter ] && . /etc/default/node_exporter
@@ -39,17 +39,17 @@ stop() {
         PID=$(cat $PIDFILE)
         # Find all child processes of the shell process
         PIDS="$PID $(pgrep -P $PID)"
-        
+
         # Send SIGTERM to all processes
         for pid in $PIDS; do
             kill -TERM $pid 2>/dev/null
         done
-        
+
         # Send SIGKILL to any remaining processes
         for pid in $PIDS; do
             kill -KILL $pid 2>/dev/null
         done
-        
+
         rm -f $PIDFILE
     else
         echo "$PIDFILE not found, $NAME may not be running"

--- a/recipes-tools/process-exporter/files/process-exporter.init
+++ b/recipes-tools/process-exporter/files/process-exporter.init
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          process-exporter
-# Required-Start:    $local_fs $network $named $time $syslog
+# Required-Start:    $local_fs $network $named $time $syslog fetch-config
 # Required-Stop:     $local_fs $network $named $time $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
@@ -40,17 +40,17 @@ stop() {
         PID=$(cat $PIDFILE)
         # Find all child processes of the shell process
         PIDS="$PID $(pgrep -P $PID)"
-        
+
         # Send SIGTERM to all processes
         for pid in $PIDS; do
             kill -TERM $pid 2>/dev/null
         done
-        
+
         # Send SIGKILL to any remaining processes
         for pid in $PIDS; do
             kill -KILL $pid 2>/dev/null
         done
-        
+
         rm -f $PIDFILE
     else
         echo "$PIDFILE not found, $NAME may not be running"

--- a/recipes-tools/prometheus/files/prometheus.init
+++ b/recipes-tools/prometheus/files/prometheus.init
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          prometheus
-# Required-Start:    $local_fs $network $named $time $syslog
+# Required-Start:    $local_fs $network $named $time $syslog fetch-config
 # Required-Stop:     $local_fs $network $named $time $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
@@ -34,17 +34,17 @@ stop() {
         PID=$(cat $PIDFILE)
         # Find all child processes of the shell process
         PIDS="$PID $(pgrep -P $PID)"
-        
+
         # Send SIGTERM to all processes
         for pid in $PIDS; do
             kill -TERM $pid 2>/dev/null
         done
-        
+
         # Send SIGKILL to any remaining processes
         for pid in $PIDS; do
             kill -KILL $pid 2>/dev/null
         done
-        
+
         rm -f $PIDFILE
     else
         echo "$PIDFILE not found, $NAME may not be running"

--- a/recipes-tools/prometheus/files/prometheus.yml.input_example
+++ b/recipes-tools/prometheus/files/prometheus.yml.input_example
@@ -26,7 +26,7 @@
     "rbuilder_metrics": {
       "enabled": true,
       "targets": [
-        "localhost:6069"
+        "localhost:6060"
       ]
     },
     "remote_write": [

--- a/recipes-tools/prometheus/prometheus.bb
+++ b/recipes-tools/prometheus/prometheus.bb
@@ -28,6 +28,7 @@ do_install() {
 
     install -d ${D}${sysconfdir}/prometheus
     install -m 0644 ${WORKDIR}/prometheus.yml.mustache ${D}${sysconfdir}/prometheus/
+    install -m 0640 ${WORKDIR}/prometheus.yml.mustache ${D}${sysconfdir}/prometheus/prometheus.yml
 
     install -d ${D}${sysconfdir}/init.d
     install -m 0755 ${WORKDIR}/prometheus.init ${D}${sysconfdir}/init.d/prometheus


### PR DESCRIPTION
- An attempt to force the services startup order with `Required-Start`. All the services that expect the configuration from BuilderHub must wait before it is fetched
- Pre-create Prometheus config with correct permissions as it contains secrets