### PR TITLE
Fix instance name template, refactor fluentbit config

### DIFF
--- a/recipes-tools/fluent-bit/files/td-agent-bit.conf.mustache
+++ b/recipes-tools/fluent-bit/files/td-agent-bit.conf.mustache
@@ -1,4 +1,3 @@
-{{#fluentbit}}
 [SERVICE]
   flush 1
   daemon off
@@ -9,14 +8,13 @@
   path /var/log/*.log
   path_key path
   db /tmp/fluentbit.db
-  tag {{input_tags}}
+  tag {{fluentbit.input_tags}}
 
 [OUTPUT]
   name cloudwatch_logs
   match *
   region us-east-2
-  log_group_name {{output_cw_log_group_name}}
-  log_stream_template $path
-  log_stream_name {{output_cw_log_stream_name}}
+  log_group_name {{fluentbit.output_cw_log_group_name}}
   log_key log
-{{/fluentbit}}
+  log_stream_template {{instance_name}}-$path
+  log_stream_prefix {{instance_name}}-

--- a/recipes-tools/prometheus/files/prometheus.yml.mustache
+++ b/recipes-tools/prometheus/files/prometheus.yml.mustache
@@ -18,10 +18,10 @@ scrape_configs:
     relabel_configs:
     - source_labels: [__address__]
       target_label: instance_name
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
     - source_labels: [__address__]
       target_label: instance
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
 
   - job_name: "node-exporter"
     metrics_path: "/metrics"
@@ -34,10 +34,10 @@ scrape_configs:
     relabel_configs:
     - source_labels: [__address__]
       target_label: instance_name
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
     - source_labels: [__address__]
       target_label: instance
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
 
   - job_name: "process-exporter"
     metrics_path: "/metrics"
@@ -50,14 +50,14 @@ scrape_configs:
     relabel_configs:
     - source_labels: [__address__]
       target_label: instance_name
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
     - source_labels: [__address__]
       target_label: instance
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
 
   {{#prometheus.lighthouse_metrics.enabled}}
   - job_name: "lighthouse"
-    metrics_path: "/"
+    metrics_path: "/metrics"
     static_configs:
     - targets: {{prometheus.lighthouse_metrics.targets}}
       labels:
@@ -67,10 +67,10 @@ scrape_configs:
     relabel_configs:
     - source_labels: [__address__]
       target_label: instance_name
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
     - source_labels: [__address__]
       target_label: instance
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
   {{/prometheus.lighthouse_metrics.enabled}}
 
 
@@ -86,10 +86,10 @@ scrape_configs:
     relabel_configs:
     - source_labels: [__address__]
       target_label: instance_name
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
     - source_labels: [__address__]
       target_label: instance
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
   {{/prometheus.reth_metrics.enabled}}
 
   {{#prometheus.rbuilder_metrics.enabled}}
@@ -104,10 +104,10 @@ scrape_configs:
     relabel_configs:
     - source_labels: [__address__]
       target_label: instance_name
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
     - source_labels: [__address__]
       target_label: instance
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
   {{/prometheus.rbuilder_metrics.enabled}}
 
   {{#prometheus.orderflow_proxy_metrics.enabled}}
@@ -122,10 +122,10 @@ scrape_configs:
     relabel_configs:
     - source_labels: [__address__]
       target_label: instance_name
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
     - source_labels: [__address__]
       target_label: instance
-      replacement: {{prometheus.instance_name}}
+      replacement: {{instance_name}}
   {{/prometheus.orderflow_proxy_metrics.enabled}}
 
 remote_write:


### PR DESCRIPTION
- Fix Fluentbit config removing `log_stream_name`. It is redundant since we're using `log_stream_template`. Add `log_stream_prefix` as a fallback if `log_stream_template` fails to evaluate
- Remove switching the scope to `fluentbit` inside the Fluentbit config file. Instead reference variables from the global scope. Mustache does not support referencing globally scoped variable from within the child scope and we need it to reference `instance_name`
- Simplify Prometheus config by referencing the global `instance_name` variable instead of Prometheus-scoped (removed from the Builder Hub schema config)