### PR TITLE
Fixes for v1.2 release of the BuilderNet image

### DIFF
--- a/recipes-tools/fluent-bit/files/fluent-bit.init
+++ b/recipes-tools/fluent-bit/files/fluent-bit.init
@@ -32,8 +32,8 @@ start() {
         echo "Error: Configuration file $CONFIG_FILE not found" >> $LOGFILE
         return 1
     fi
-	touch $LOGFILE
-	chown $USER:$GROUP $LOGFILE
+    touch $LOGFILE
+    chown $USER:$GROUP $LOGFILE
     chmod 644 $LOGFILE
     start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --chuid $USER:$GROUP \
         --exec /bin/sh -- -c "exec $DAEMON $DAEMON_ARGS &> $LOGFILE"

--- a/recipes-tools/fluent-bit/files/fluent-bit.init
+++ b/recipes-tools/fluent-bit/files/fluent-bit.init
@@ -32,8 +32,11 @@ start() {
         echo "Error: Configuration file $CONFIG_FILE not found" >> $LOGFILE
         return 1
     fi
+	touch $LOGFILE
+	chown $USER:$GROUP $LOGFILE
+    chmod 644 $LOGFILE
     start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --chuid $USER:$GROUP \
-        --exec /bin/sh -- -c "exec $DAEMON $DAEMON_ARGS 2>&1 | tee -a $LOGFILE"
+        --exec /bin/sh -- -c "exec $DAEMON $DAEMON_ARGS &> $LOGFILE"
     echo "$NAME started. Log file: $LOGFILE"
 }
 

--- a/recipes-tools/fluent-bit/files/td-agent-bit.conf.mustache
+++ b/recipes-tools/fluent-bit/files/td-agent-bit.conf.mustache
@@ -18,6 +18,13 @@
   tag {{fluentbit.input_tags}}
   parser cri
 
+# In logs parsed by `cri` rename message -> log
+[FILTER]
+  name modify
+  match *
+  rename message log
+  condition key_exists logtag
+
 [OUTPUT]
   name cloudwatch_logs
   match *

--- a/recipes-tools/process-exporter/files/process-exporter.init
+++ b/recipes-tools/process-exporter/files/process-exporter.init
@@ -27,6 +27,7 @@ start() {
         return 1
     fi
     echo "Starting $NAME…"
+    chown $USER:$GROUP $CONFIG
     start-stop-daemon --start --quiet --background \
         --make-pidfile --pidfile $PIDFILE \
         --chuid $USER:$GROUP \


### PR DESCRIPTION
Various fixes for v1.2 release of the BuilderNet image:
- Add Fluent Bit filter to rename `message` field to `log` when parsing container logs with CRI plugin. `log` field is where the output expects to find an actual log message.
- Fix Fluentbit startup script.