### PR TITLE
Inline Prometheus credentials

### DIFF
--- a/recipes-tools/prometheus/files/prometheus.yml.mustache
+++ b/recipes-tools/prometheus/files/prometheus.yml.mustache
@@ -160,12 +160,12 @@ remote_write:
     {{#basic_auth}}
     basic_auth:
       username: {{username}}
-      password_file: {{password_file}}
+      password: {{password}}
     {{/basic_auth}}
 
     {{#authorization}}
     authorization:
       type: {{type}}
-      credentials_file: {{credentials_file}}
+      credentials: {{credentials}}
     {{/authorization}}
   {{/prometheus.remote_write}}


### PR DESCRIPTION
Allow putting credentials for basic auth and `authorization` directly into the Prometheus config. Using `password_file` and `credentials_file` requires orchestrating multiple files upload on System API side -- the complexity I want to avoid.

The config file is already owned by Prometheus and has permissions tied to `prometheus` user so other process on the system can't read it.