### PR TITLE
Rename log field in the CRI parser

### DIFF
--- a/recipes-tools/fluent-bit/files/0008-cri-parsers.patch
+++ b/recipes-tools/fluent-bit/files/0008-cri-parsers.patch
@@ -1,0 +1,15 @@
+Upstream-Status: Inappropriate [embedded specific]
+==================================================
+diff --git a/conf/parsers.conf b/conf/parsers.conf
+index 77f61ce03..f5a636a61 100644
+--- a/conf/parsers.conf
++++ b/conf/parsers.conf
+@@ -106,7 +106,7 @@
+     # http://rubular.com/r/tjUt3Awgg4
+     Name cri
+     Format regex
+-    Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
++    Regex ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
+     Time_Key    time
+     Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+

--- a/recipes-tools/fluent-bit/files/td-agent-bit.conf.mustache
+++ b/recipes-tools/fluent-bit/files/td-agent-bit.conf.mustache
@@ -18,13 +18,6 @@
   tag {{fluentbit.input_tags}}
   parser cri
 
-# In logs parsed by `cri` rename message -> log
-[FILTER]
-  name modify
-  match *
-  rename message log
-  condition key_exists logtag
-
 [OUTPUT]
   name cloudwatch_logs
   match *


### PR DESCRIPTION
Rename log field in the CRI parser to match the regular (non-container) logs. 

Taken from: https://github.com/microsoft/fluentbit-containerd-cri-o-json-log/blob/main/config.yaml#L83