### PR TITLE
Allow fluentbit-podman to mount `/var/log`

### DIFF
--- a/recipes-tools/fluent-bit-podman/init
+++ b/recipes-tools/fluent-bit-podman/init
@@ -25,6 +25,7 @@ FLUENT_BIT_GROUP=fluentbit
 start_fluent_bit() {
     podman run -dt --rm --restart on-failure --name $NAME \
         --user $(id -u $FLUENT_BIT_USER):$(id -g $FLUENT_BIT_GROUP) \
+        -v /var/log:/var/log \
         -v $FLUENT_BIT_CONFIG_FILE:/td-agent-bit.conf \
         -v $FLUENT_BIT_PARSERS_CONFIG_FILE:/parsers.conf \
         --log-opt path=$LOGFILE --log-opt max-size=10mb \
@@ -39,6 +40,7 @@ start() {
     install -d -m 755 $LOG_DIR
     touch $LOGFILE
     chown fluentbit:fluentbit $LOGFILE
+    chmod 644 $LOGFILE
 
     if [ ! -f "$FLUENT_BIT_CONFIG_FILE" ]; then
         echo "Error: Configuration file $FLUENT_BIT_CONFIG_FILE not found" >> $LOGFILE


### PR DESCRIPTION
Fixing current permissions errors:

```bash
[2025/09/04 08:11:29] [error] [input:tail:tail.1] read error, check permissions: /var/log/containers/*.log
[2025/09/04 08:11:29] [ warn] [input:tail:tail.1] error scanning path: /var/log/containers/*.log
```

Tested the change in the staging VM and it worked:

```bash
[2025/09/04 08:46:35] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Created log stream XXX-/var/log/containers/td-agent-bit.log
[2025/09/04 08:46:36] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Creating log stream XXX-/var/log/lighthouse.log in log group /azure/instance/buildernet
[2025/09/04 08:46:37] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Created log stream XXX-/var/log/lighthouse.log
[2025/09/04 08:46:37] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Creating log stream XXX-/var/log/reth.log in log group /azure/instance/buildernet
[2025/09/04 08:46:37] [ info] [output:cloudwatch_logs:cloudwatch_logs.0] Created log stream XXX-/var/log/reth.log
```